### PR TITLE
Update Vbox IP address following bosh-lite changes

### DIFF
--- a/environment/bosh_login.sh
+++ b/environment/bosh_login.sh
@@ -3,4 +3,4 @@ source ./environment/bosh_env.sh
 
 export BOSH_CLIENT=admin
 export BOSH_CLIENT_SECRET=`bosh int $DEPLOYMENT_DIRECTORY/creds.yml --path /admin_password`
-bosh alias-env $BOSH_ENV_ALIAS -e 192.168.50.6 --ca-cert <(bosh int $DEPLOYMENT_DIRECTORY/creds.yml --path /director_ssl/ca)
+bosh alias-env $BOSH_ENV_ALIAS -e 192.168.56.6 --ca-cert <(bosh int $DEPLOYMENT_DIRECTORY/creds.yml --path /director_ssl/ca)


### PR DESCRIPTION
This change is update from bosh-lite new ip address to support Vbox version 6.1.28+